### PR TITLE
Feat: getElementsFromChildren 유틸 함수 작성

### DIFF
--- a/utils/getElementsFromChildren.ts
+++ b/utils/getElementsFromChildren.ts
@@ -1,0 +1,22 @@
+import { Children, ReactNode, ReactElement, isValidElement } from "react";
+
+interface Props {
+  children: ReactNode;
+  targetElement: ReactElement;
+}
+
+/**
+ * Children에서 targetElement와 같은 type의 element를 골라내어주는 함수
+ * (ex. targetElement가 <DropdownTrigger />인 경우 DropdownTrigger만 골라내어 []로 return)
+ */
+export default function getElementsFromChildren({
+  children,
+  targetElement,
+}: Props) {
+  const childrenArray = Children.toArray(children);
+  const returnElements = childrenArray.filter(
+    (child) => isValidElement(child) && child.type === targetElement.type,
+  );
+
+  return returnElements;
+}


### PR DESCRIPTION
## 작업 내용

- getElementsFromChildren 유틸 함수 작성
- children에서 targetElement와 같은 type의 element를 찾아서 array로 해당 react element를 리턴해주는 함수
- 사용예시
```tsx
export function ItemContent({ children }) {
  const ItemElements = getElementsFromChildren({
    children,
    targetElement: <Item />,
  });

  return (
    <ul className="p-2">
      {children}
    </ul>
  );
}
```
```tsx
// 결과 예시
<ItemContent>
  <Item prop={prop1} />
  <Item prop={prop2} />
  <div>
    <Item prop={prop3} />
  </div>
</ItemContent>

// ItemElements: [<Item prop={prop1} />, <Item prop={prop2} />]
```

## 기타

- Closes: #6 