### PR TITLE
Feat: Slot 컴포넌트 제작

### DIFF
--- a/app/_components/Slot.tsx
+++ b/app/_components/Slot.tsx
@@ -1,0 +1,26 @@
+import { cloneElement, isValidElement, ReactElement, ReactNode } from "react";
+
+interface SlotProps extends React.HTMLAttributes<HTMLElement> {
+  children: ReactNode;
+}
+
+/**
+ * Slot 내부의 유일한 children react element에 Slot의 props를 전달하여
+ * 하나의 react element로 보이도록 하는 컴포넌트
+ */
+export default function Slot({ children, ...props }: SlotProps) {
+  if (isValidElement(children)) {
+    const childProps = (children as ReactElement).props || {};
+
+    return cloneElement(children, {
+      ...props,
+      ...childProps,
+    });
+  }
+
+  console.warn(
+    "Slot은 children으로 오직 하나의 react element를 가져야 합니다.",
+  );
+
+  return null;
+}


### PR DESCRIPTION
## 작업 내용
- Slot 컴포넌트 제작
- radix-ui의 asChild에 사용되는 Slot 컴포넌트와 유사한 Render delegation을 수행
- Slot 내부의 유일한 children react element에 Slot의 props를 전달하여 하나의 react element로 보이도록 랜더링 하는 컴포넌트
- 사용예시
```tsx
<Slot className="p-2" onClick={handleClick}>
  <button>버튼</button>
</Slot>
```
```tsx
// 실제 랜더링 되는 형태
<button className="p-2" onClick={handleClick}>
  버튼
</button>
```

## 기타

- Closes: #5 