### PR TITLE
Feat: padZero 유틸 함수 작성

### DIFF
--- a/utils/padZero.ts
+++ b/utils/padZero.ts
@@ -1,0 +1,6 @@
+/**
+ * length에 맞추어 number 앞에 숫자 0을 붙힌 string을 리턴하는 함수
+ */
+export default function padZero(number: number, length: number) {
+  return String(number).padStart(length, "0");
+}


### PR DESCRIPTION
## 작업 내용

- getElementsFromChildren 유틸 함수 작성
- length에 맞추어 number 앞에 숫자 0을 붙인 string을 리턴하는 함수
- 사용예시
```tsx
// padZero(number, length)
padZero(2, 3); // "002"
padZero(23, 3); // "023"
padZero(3, 2); // "03"
```

## 기타

- Closes: #12 