### PR TITLE
Feat: 랜딩 페이지 메뉴 UI 구현

### DIFF
--- a/app/(pages)/_components/DefaultMenu.tsx
+++ b/app/(pages)/_components/DefaultMenu.tsx
@@ -1,0 +1,110 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import { HorizontalLine as Line } from "@/app/_components/Line";
+import { Item, MenuData, MenuItem } from "@/lib/types/menu";
+
+interface MenuContainerProps {
+  children: ReactNode;
+}
+
+function MenuContainer({ children }: MenuContainerProps) {
+  return (
+    <div className="relative mx-auto flex h-[482px] w-full gap-[26px] text-white lg:w-[900px] xl:w-[1046px] 2xl:w-[1280px]">
+      {children}
+    </div>
+  );
+}
+
+interface MenuGroupProps {
+  titleItem: Item;
+  menuItems: MenuItem[];
+  lastGroup?: boolean;
+}
+
+function MenuGroup({
+  titleItem,
+  menuItems,
+  lastGroup = false,
+}: MenuGroupProps) {
+  return (
+    <div className={lastGroup ? "pr-[26px]" : "grow"}>
+      <h3 className="flex items-center gap-[26px]">
+        <Link className="text-[22px] font-bold" href={titleItem.href}>
+          {titleItem.label}
+        </Link>
+        {!lastGroup && <Line />}
+      </h3>
+      <ul className="mt-5 flex flex-col gap-3 text-[14px] font-normal text-opacity-80">
+        {menuItems.map((item) => (
+          <li key={item.label}>
+            <Link href={item.href}>{item.label}</Link>
+            {item.subItems && <SubMenu subItems={item.subItems} />}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface SubMenuProps {
+  subItems: Item[];
+}
+
+function SubMenu({ subItems }: SubMenuProps) {
+  return (
+    <ul className="text-submenuText mt-2 flex flex-col gap-1 pl-1 text-[14px]">
+      {subItems.map((subItem) => (
+        <li key={subItem.label}>
+          <span>- </span>
+          <Link href={subItem.href}>{subItem.label}</Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function MenuFooter() {
+  return (
+    <footer className="absolute bottom-0 flex w-full items-center">
+      <div className="text-[22px] font-bold">AUDITION</div>
+      <Line className="mx-[26px] px-[26px] lg:w-[570px] xl:w-[700px] 2xl:w-[950px]" />
+      <div className="text-[22px] font-bold">RECRUIT</div>
+    </footer>
+  );
+}
+
+function MenuLabel() {
+  return (
+    <>
+      <div className="text-submenuText absolute right-[48px] rotate-90 text-[14px] text-opacity-50">
+        MENU
+      </div>
+      <div className="text-submenuText absolute left-[48px] -rotate-90 text-[14px] text-opacity-50">
+        MENU
+      </div>
+    </>
+  );
+}
+
+interface DefaultMenuProps {
+  menuDataList: MenuData[];
+}
+
+export default function DefaultMenu({ menuDataList }: DefaultMenuProps) {
+  return (
+    <menu className="bg-menuBg fixed inset-0 -z-10 hidden place-items-center overflow-y-auto py-24 lg:grid">
+      <MenuContainer>
+        {menuDataList.map((menuData, index) => (
+          <MenuGroup
+            key={menuData.titleItem.label}
+            titleItem={menuData.titleItem}
+            menuItems={menuData.menuItems}
+            lastGroup={index === menuDataList.length - 1}
+          />
+        ))}
+        <MenuFooter />
+      </MenuContainer>
+      <MenuLabel />
+    </menu>
+  );
+}

--- a/app/(pages)/_components/Menu.tsx
+++ b/app/(pages)/_components/Menu.tsx
@@ -2,6 +2,9 @@
 
 import useToggle from "@/hooks/useToggle";
 import { twMerge, twJoin } from "tailwind-merge";
+import DefaultMenu from "./DefaultMenu";
+import MobileMenu from "./MobileMenu";
+import { MenuData } from "@/lib/types/menu";
 
 interface HamburgerButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   isOpen: boolean;
@@ -64,11 +67,65 @@ function MobileMenuCloseButton({
       className={twMerge("relative h-[20px] w-[20px]", className)}
       {...props}
     >
-      <span className="absolute top-1/2 h-[2px] w-[20px] rotate-[-45deg] rounded bg-white" />
-      <span className="absolute top-1/2 h-[2px] w-[20px] rotate-[45deg] rounded bg-white" />
+      <span className="absolute left-1/2 top-1/2 h-[2px] w-[20px] -translate-x-1/2 -translate-y-1/2 rotate-[-45deg] rounded bg-white" />
+      <span className="absolute left-1/2 top-1/2 h-[2px] w-[20px] -translate-x-1/2 -translate-y-1/2 rotate-[45deg] rounded bg-white" />
     </button>
   );
 }
+
+const MENU_DATA_LIST = [
+  {
+    titleItem: { label: "JYP", href: "#" },
+    menuItems: [
+      { label: "ABOUT JYP", href: "#" },
+      { label: "HISTORY", href: "#" },
+      { label: "NOTICE", href: "#" },
+      { label: "CONTACT", href: "#" },
+    ],
+  },
+  {
+    titleItem: { label: "ARTIST", href: "#" },
+    menuItems: [
+      { label: "ARTIST", href: "#" },
+      { label: "ALBUM", href: "#" },
+      { label: "VIDEO", href: "#" },
+    ],
+  },
+  {
+    titleItem: { label: "SUSTAINABILITY", href: "#" },
+    menuItems: [
+      { label: "ESG STRATEGY", href: "#" },
+      {
+        label: "ESG FACTBOOK",
+        href: "#",
+        subItems: [
+          { label: "ENVIRONMENTAL", href: "#" },
+          { label: "SOCIAL", href: "#" },
+          { label: "GOVERNANCE", href: "#" },
+        ],
+      },
+      { label: "ESG REPORTING", href: "#" },
+    ],
+  },
+  {
+    titleItem: { label: "IR", href: "#" },
+    menuItems: [
+      {
+        label: "STOCK INFO.",
+        href: "#",
+        subItems: [
+          { label: "STOCK INFORMATION", href: "#" },
+          { label: "DIVIDENES STATUS", href: "#" },
+        ],
+      },
+      { label: "FINANCIAL INFO.", href: "#" },
+      { label: "PUBLIC DISCLOSURE INFO.", href: "#" },
+      { label: "DATA & MATERIALS", href: "#" },
+      { label: "NEWS", href: "#" },
+      { label: "IR INQUIRY", href: "#" },
+    ],
+  },
+];
 
 export default function Menu() {
   const [isMenuOpen, toggleMenuOpen] = useToggle(false);
@@ -80,10 +137,13 @@ export default function Menu() {
       <HamburgerButton isOpen={isMenuOpen} onClick={handleMenuButtonClick} />
       {isMenuOpen && (
         <>
-          <menu className="fixed inset-0 -z-10 hidden bg-[#0f0e0e] lg:block"></menu>
-          <menu className="fixed inset-0 z-10 block bg-[#0f0e0e] lg:hidden">
-            <MobileMenuCloseButton onClick={handleMenuButtonClick} />
-          </menu>
+          <DefaultMenu menuDataList={MENU_DATA_LIST as MenuData[]} />
+          <MobileMenu
+            closeButton={
+              <MobileMenuCloseButton onClick={handleMenuButtonClick} />
+            }
+            menuDataList={MENU_DATA_LIST as MenuData[]}
+          />
         </>
       )}
     </>

--- a/app/(pages)/_components/MobileFamilyDropdown.tsx
+++ b/app/(pages)/_components/MobileFamilyDropdown.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import {
+  Dropdown,
+  DropdownContent,
+  DropdownItem,
+  DropdownTrigger,
+} from "@/app/_components/Dropdown";
+
+export default function MobileFamilyDropdown() {
+  return (
+    <Dropdown>
+      <DropdownTrigger className="bg-menuBg relative flex h-[33px] w-[188px] items-center justify-center text-[13px] font-medium text-white">
+        FAMILY
+        <Image
+          src="/icons/fi-sr-caret-down.svg"
+          alt="dropdown arrow"
+          width={12}
+          height={12}
+          className="absolute right-[20px]"
+        />
+      </DropdownTrigger>
+      <DropdownContent
+        position="upper"
+        className="bg-menuBg flex w-[188px] flex-col items-center justify-center gap-2 pb-1 text-[13px] font-light text-white"
+      >
+        <DropdownItem>
+          <Link className="border-blue-400 pb-[2px] hover:border-b-2" href="#">
+            JYP AUDITION
+          </Link>
+        </DropdownItem>
+        <DropdownItem>
+          <Link className="border-blue-400 pb-[2px] hover:border-b-2" href="#">
+            JYP RECRUIT
+          </Link>
+        </DropdownItem>
+        <DropdownItem>
+          <Link className="border-blue-400 pb-[2px] hover:border-b-2" href="#">
+            JYP FANS
+          </Link>
+        </DropdownItem>
+        <DropdownItem>
+          <Link className="border-blue-400 pb-[2px] hover:border-b-2" href="#">
+            JYP EDM
+          </Link>
+        </DropdownItem>
+        <DropdownItem>
+          <Link className="border-blue-400 pb-[2px] hover:border-b-2" href="#">
+            JYP PUBLISHING
+          </Link>
+        </DropdownItem>
+        <DropdownItem>
+          <Link className="border-blue-400 pb-[2px] hover:border-b-2" href="#">
+            JYP SHOP
+          </Link>
+        </DropdownItem>
+        <DropdownItem>
+          <Link className="border-blue-400 pb-[2px] hover:border-b-2" href="#">
+            JYP THREE SIXTY
+          </Link>
+        </DropdownItem>
+        <DropdownItem>
+          <Link className="border-blue-400 pb-[2px] hover:border-b-2" href="#">
+            JYP PARTNERS
+          </Link>
+        </DropdownItem>
+      </DropdownContent>
+    </Dropdown>
+  );
+}

--- a/app/(pages)/_components/MobileMenu.tsx
+++ b/app/(pages)/_components/MobileMenu.tsx
@@ -1,0 +1,178 @@
+import Link from "next/link";
+import { ReactNode } from "react";
+import { VerticalLine, HorizontalLine } from "@/app/_components/Line";
+import Image from "next/image";
+import MobileFamilyDropdown from "./MobileFamilyDropdown";
+import { Item, MenuData, MenuItem } from "@/lib/types/menu";
+
+interface MobileMenuHeaderProps {
+  closeButton: ReactNode;
+}
+
+function MobileMenuHeader({ closeButton }: MobileMenuHeaderProps) {
+  return (
+    <header className="mx-4 mt-5 flex items-center justify-between">
+      <ul className="flex items-center gap-3 text-[12px] font-normal text-white">
+        <li>
+          <button className="border-b-2 border-blue-400">KO</button>
+        </li>
+        <VerticalLine />
+        <li>
+          <button>EN</button>
+        </li>
+        <VerticalLine />
+        <li>
+          <button>CH</button>
+        </li>
+        <VerticalLine />
+        <li>
+          <button>JP</button>
+        </li>
+        <VerticalLine />
+        <li>
+          <button>ES</button>
+        </li>
+      </ul>
+      {closeButton}
+    </header>
+  );
+}
+
+function MobileMenuFooter() {
+  return (
+    <footer className="h-[166px] bg-[#242426] px-[15px] pb-[30px] pt-[14px]">
+      <ul className="flex items-center justify-center gap-5">
+        <li className="bg-menuBg flex h-[32px] w-[32px] items-center justify-center rounded-full">
+          <Image
+            src="/sns/youtube-icon.svg"
+            alt="youtube"
+            width={18}
+            height={18}
+            className="opacity-50"
+          />
+        </li>
+        <li className="bg-menuBg flex h-[32px] w-[32px] items-center justify-center rounded-full">
+          <Image
+            src="/sns/instagram-icon.svg"
+            alt="instagram"
+            width={16}
+            height={16}
+            className="opacity-50"
+          />
+        </li>
+        <li className="bg-menuBg flex h-[32px] w-[32px] items-center justify-center rounded-full">
+          <Image
+            src="/sns/twitter-icon.svg"
+            alt="x"
+            width={15}
+            height={15}
+            className="opacity-50"
+          />
+        </li>
+        <li className="bg-menuBg flex h-[32px] w-[32px] items-center justify-center rounded-full">
+          <Image
+            src="/sns/facebook-icon.svg"
+            alt="facebook"
+            width={16}
+            height={16}
+            className="opacity-50"
+          />
+        </li>
+      </ul>
+      <div className="my-5 flex items-center justify-center">
+        <MobileFamilyDropdown />
+      </div>
+      <div className="text-footerText gap-6 text-center text-[11px]">
+        <Link href="#" className="underline">
+          개인정보처리방침
+        </Link>
+        <span className="ml-[15px]">@ JYP ENTERTAINMENT Corp.</span>
+      </div>
+    </footer>
+  );
+}
+
+interface MenuGroupProps {
+  titleItem: Item;
+  menuItems: MenuItem[];
+}
+
+function MenuGroup({ titleItem, menuItems }: MenuGroupProps) {
+  return (
+    <div className="mb-6">
+      <h3 className="mb-3 flex items-center gap-[24px]">
+        <Link
+          className="text-[18px] font-bold text-white"
+          href={titleItem.href}
+        >
+          {titleItem.label}
+        </Link>
+        <HorizontalLine />
+      </h3>
+      <ul className="text-menuText flex flex-col gap-3 text-[14px] font-normal">
+        {menuItems.map((item) => (
+          <li key={item.label}>
+            <Link href={item.href}>{item.label}</Link>
+            {item.subItems && <SubMenu subItems={item.subItems} />}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface SubMenuProps {
+  subItems: Item[];
+}
+
+function SubMenu({ subItems }: SubMenuProps) {
+  return (
+    <ul className="text-submenuText mt-2 flex flex-col gap-1.5 pl-1 text-[14px] text-opacity-80">
+      {subItems.map((subItem) => (
+        <li key={subItem.label}>
+          <span>- </span>
+          <Link href={subItem.href}>{subItem.label}</Link>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface MobileMenuProps extends MobileMenuHeaderProps {
+  menuDataList: MenuData[];
+}
+
+export default function MobileMenu({
+  closeButton,
+  menuDataList,
+}: MobileMenuProps) {
+  return (
+    <menu className="bg-menuBg fixed inset-0 z-10 block overflow-y-auto lg:hidden">
+      <MobileMenuHeader closeButton={closeButton} />
+      <section className="pb-[54px] pl-[15px] pt-[70px]">
+        {menuDataList.map((menuData) => (
+          <MenuGroup
+            key={menuData.titleItem.label}
+            titleItem={menuData.titleItem}
+            menuItems={menuData.menuItems}
+          />
+        ))}
+        <div className="mt-[56px] text-[18px] font-bold text-white">
+          <div className="flex items-center">
+            <Link className="w-[150px] flex-shrink-0" href="#">
+              AUDITION
+            </Link>
+            <HorizontalLine />
+          </div>
+          <div className="mt-5 flex items-center">
+            <Link className="w-[150px] flex-shrink-0" href="#">
+              RECRUIT
+            </Link>
+            <HorizontalLine />
+          </div>
+        </div>
+      </section>
+      <MobileMenuFooter />
+    </menu>
+  );
+}

--- a/app/_components/Line.tsx
+++ b/app/_components/Line.tsx
@@ -1,0 +1,17 @@
+import { twMerge } from "tailwind-merge";
+
+interface HorizontalLineProps {
+  className?: string;
+}
+
+export function HorizontalLine({ className }: HorizontalLineProps) {
+  return (
+    <span
+      className={twMerge("h-[1px] w-full bg-white opacity-50", className)}
+    />
+  );
+}
+
+export function VerticalLine() {
+  return <span className="h-[10px] w-[1px] bg-white opacity-50" />;
+}

--- a/lib/types/menu.ts
+++ b/lib/types/menu.ts
@@ -1,0 +1,13 @@
+export type Item = {
+  label: string;
+  href: string;
+};
+
+export interface MenuItem extends Item {
+  subItems?: Item[];
+}
+
+export interface MenuData {
+  titleItem: Item;
+  menuItems: MenuItem[];
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,13 @@ export default {
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
+    screens: {
+      sm: "640px",
+      md: "768px",
+      lg: "1024px",
+      xl: "1164px",
+      "2xl": "1392px",
+    },
     extend: {
       keyframes: {
         "slide-down-in": {
@@ -33,8 +40,11 @@ export default {
         "slide-down-out": "slide-down-out 0.2s ease-in-out",
       },
       colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
+        menuBg: "#0f0e0e",
+        footerBg: "#242426",
+        menuText: "#959595",
+        submenuText: "#a0a0a0",
+        footerText: "#e5e8e8",
       },
     },
   },


### PR DESCRIPTION
## 작업 내용
- 랜딩 페이지 메뉴 UI 구현 (기본 및 모바일 환경)
- tailwind 커스텀 색상 값 추가
- 메뉴 데이터 타입 정의 (/lib/types/menu.ts)
- Line 공통 컴포넌트 추가 (현재는 menu에서만 사용)

## 이미지
- 기본 UI
![image](https://github.com/user-attachments/assets/368fa2b9-1ce0-4a49-8c1d-7d620fd0dfad)
- 모바일 UI (아래 생략)
![image](https://github.com/user-attachments/assets/e6baa9f1-f790-404e-a9fb-e223886c01f9)


## 기타

- Closes: #18 