### PR TITLE
Fix: Carousel 애니메이션 오류 수정

### DIFF
--- a/app/_components/Carousel.tsx
+++ b/app/_components/Carousel.tsx
@@ -133,6 +133,10 @@ export function Carousel({ children, className }: CarouselProps) {
     } else {
       setCurrentSlideNum((prev) => prev - 1);
       setCurrentSlideIdx((prev) => prev - 1);
+
+      setTimeout(() => {
+        setIsAnimating(false);
+      }, 300);
     }
   };
 
@@ -151,6 +155,10 @@ export function Carousel({ children, className }: CarouselProps) {
     } else {
       setCurrentSlideNum((prev) => prev + 1);
       setCurrentSlideIdx((prev) => prev + 1);
+
+      setTimeout(() => {
+        setIsAnimating(false);
+      }, 300);
     }
   };
 


### PR DESCRIPTION
## 작업 내용
-  2번째 페이지 이후부터 캐러셀의 slide animation이 사라지지 않는 문제
  - 페이지 이동 동작 이후 isAnimation값을 false로 변경하는 로직 추가

## 기타
- Closes: #32 